### PR TITLE
Override the default error handler when custom error handler is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
   - [requestInterceptor](#requestinterceptor)
   - [responseInterceptor](#responseinterceptor)
   - [init](#init)
+  - [disableDefaultErrorHandler](#disabledefaulterrorhandler)
   - [errorHandler](#errorhandler)
 - [Helpers](#helpers)
   - [Fetch Style Requests](#fetch-style-requests)
@@ -69,7 +70,7 @@
 Install with npm:
 ```bash
 >_ npm install @nuxtjs/axios
-``` 
+```
 
 Install with yarn:
 ```bash
@@ -206,7 +207,7 @@ responseInterceptor: (response, ctx) => {
 ```
 
 
-Function for manipulating axios responses. 
+Function for manipulating axios responses.
 
 ### `init`
 - Default: `null`
@@ -221,11 +222,19 @@ axios: {
 }
 ```
 
+### `disableDefaultErrorHandler`
+- Default: `false`
+
+If you want to disable the default error handler for some reason, you can do it so
+by setting the option `disableDefaultErrorHandler` to true.
+
 ### `errorHandler`
 - Default: (Return promise rejection with error)
 
-Function for custom global error handler. 
+Function for custom global error handler.
 This example uses nuxt default error page.
+
+If you define a custom error handler, the default error handler provided by this package will be overridden.
 
 ```js
 axios: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ module.exports = function nuxtAxios (moduleOptions) {
     proxyHeaders: true,
     proxyHeadersIgnore: ['accept', 'host'],
     debug: false,
+    disableErrorHandler: false,
     redirectError: {}
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ module.exports = function nuxtAxios (moduleOptions) {
     proxyHeaders: true,
     proxyHeadersIgnore: ['accept', 'host'],
     debug: false,
-    disableErrorHandler: false,
+    disableDefaultErrorHandler: false,
     redirectError: {}
   }
 

--- a/lib/plugin.template.js
+++ b/lib/plugin.template.js
@@ -172,13 +172,13 @@ export default <% if (options.init) { %>async<% } %>(ctx, inject) => {
   const resInter = <%= serialize(options.responseInterceptor).replace('responseInterceptor(', 'function(').replace('function function', 'function') %>
   axios.interceptors.response.use(config => resInter(config, ctx))
   <% } %>
-  
-  // Error handler
-  axios.interceptors.response.use(undefined, err => errorHandler(err, ctx));
 
+  // Error handler
   <% if (options.errorHandler) { %>
   // Custom error handler
   axios.interceptors.response.use(undefined, err => customErrorHandler(err, ctx))
+  <% } else if (!options.disableErrorHandler) { %>
+  axios.interceptors.response.use(undefined, err => errorHandler(err, ctx));
   <% } %>
 
   // Inject axios to the context as $axios

--- a/lib/plugin.template.js
+++ b/lib/plugin.template.js
@@ -177,7 +177,7 @@ export default <% if (options.init) { %>async<% } %>(ctx, inject) => {
   <% if (options.errorHandler) { %>
   // Custom error handler
   axios.interceptors.response.use(undefined, err => customErrorHandler(err, ctx))
-  <% } else if (!options.disableErrorHandler) { %>
+  <% } else if (options.disableDefaultErrorHandler === false) { %>
   axios.interceptors.response.use(undefined, err => errorHandler(err, ctx));
   <% } %>
 


### PR DESCRIPTION
Otherwise there is the possibility that they are conflicting with each other.

Also added a option, where you can disable the errorHandler at all (for example if you want to work with the responseInterceptor)