### PR TITLE
API factory pattern enabler

### DIFF
--- a/lib/plugin.template.js
+++ b/lib/plugin.template.js
@@ -133,7 +133,7 @@ const setupProgress = (axios, ctx) => {
 }<% } %>
   
 <% if (options.api) { %> 
-  const enableApiMode = (axios, ctx, inject, apiFactory) => {
+const enableApiMode = (axios, ctx, inject, apiFactory) => {
     const api = apiFactory(axios)
     ctx.$api = api
     inject("api", api)  
@@ -179,7 +179,7 @@ export default (ctx, inject) => {
   <% if (options.credentials) { %>setupCredentialsInterceptor(axios)<% } %>
   <% if (options.progress) { %>setupProgress(axios, ctx) <% } %>
   <% if (options.retry) { %>axiosRetry(axios, <%= serialize(options.retry) %>)<% } %>
-  <% if (options.api) { %>enableApiMode(axios, ctx, <%= options.api.factory %>)<% } %>
+  <% if (options.api) { %>enableApiMode(axios, ctx, inject, <%= options.api.factory %>)<% } %>
 
   // Inject axios to the context as $axios
   ctx.$axios = axios

--- a/lib/plugin.template.js
+++ b/lib/plugin.template.js
@@ -131,6 +131,13 @@ const setupProgress = (axios, ctx) => {
   axios.defaults.onUploadProgress = onProgress
   axios.defaults.onDownloadProgress = onProgress
 }<% } %>
+  
+<% if (options.api) { %> 
+  const enableApiMode = (axios, ctx, inject, apiFactory) => {
+    const api = apiFactory(axios)
+    ctx.$api = api
+    inject("api", api)  
+ }<% } %>
 
 export default (ctx, inject) => {
   const axiosOptions = {
@@ -172,6 +179,7 @@ export default (ctx, inject) => {
   <% if (options.credentials) { %>setupCredentialsInterceptor(axios)<% } %>
   <% if (options.progress) { %>setupProgress(axios, ctx) <% } %>
   <% if (options.retry) { %>axiosRetry(axios, <%= serialize(options.retry) %>)<% } %>
+  <% if (options.api) { %>enableApiMode(axios, ctx, <%= options.api.factory %>)<% } %>
 
   // Inject axios to the context as $axios
   ctx.$axios = axios


### PR DESCRIPTION
Following discussion [here](nuxt-community#101) I thought it would be very useful to provide api definer feature from nuxt/axios module itself. This is a common pattern and putting it here perfectly fits in Nuxt way of doing things.

### UseCase: Many prefer to define their api in a file and use that rather than calling axios directly.

This patch makes it very  easy.
Basically, user would define the api in a file e.g. `api-def.js`
```
export default axios => ({
  getOrders(period = "Today") {
    return axios.get(`api/orders?period=${period}`)
  },
  getUsers() {
    return axios.get(`/api/users`)
  }
})
```
then in nuxt.config.js
```
import apiFactory from "./api-def.js"
....
axios: {
    ....
    api: { factory: apiFactory }
  },
```
and that is it. Api woulld be available to plugins, actions, mutators and components
```
 -> app.$api or ctx.$api
 -> this.$api in vue components
 -> this.$api in store actions/mutations
```

This looks so much better
```
async asyncData({ $api }) {
    let { data } = await $api.getOrders("yesterday")
    return { orders: data }
  },
```