### PR TITLE
Fix onProgress

### DIFF
--- a/lib/plugin.template.js
+++ b/lib/plugin.template.js
@@ -136,6 +136,9 @@ const setupProgress = (axios, ctx) => {
   })
 
   const onProgress = e => {
+    if (!currentRequests) {
+      return
+    }
     const progress = ((e.loaded * 100) / (e.total * currentRequests))
     $loading().set(Math.min(100, progress))
   }


### PR DESCRIPTION
Fix for #116: if `currentRequests === 0` then the $loading is always set to 100