### PR TITLE
Typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,19 @@
+import { AxiosInstance, AxiosRequestConfig, AxiosPromise } from 'axios'
+import Vue from 'vue'
+
+interface NuxtAxiosInstance extends AxiosInstance {
+  $request<T = any>(config: AxiosRequestConfig): AxiosPromise<T>
+  $get<T = any>(url: string, config?: AxiosRequestConfig): AxiosPromise<T>
+  $delete<T = any>(url: string, config?: AxiosRequestConfig): AxiosPromise<T>
+  $head<T = any>(url: string, config?: AxiosRequestConfig): AxiosPromise<T>
+  $options<T = any>(url: string, config?: AxiosRequestConfig): AxiosPromise<T>
+  $post<T = any>(url: string, data?: any, config?: AxiosRequestConfig): AxiosPromise<T>
+  $put<T = any>(url: string, data?: any, config?: AxiosRequestConfig): AxiosPromise<T>
+  $patch<T = any>(url: string, data?: any, config?: AxiosRequestConfig): AxiosPromise<T>
+}
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $axios: NuxtAxiosInstance
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Secure and easy axios integration with Nuxt.js",
   "license": "MIT",
   "main": "lib/module.js",
+  "types": "index.d.ts",
   "repository": "https://github.com/nuxt-community/axios-module",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This fixes #19 and #75.

Without typescript definitions, this code in `pages/index.vue`:

```vue
<template>
<div>
 <button @click="check">Click me</button>
 res = {{ res }}
</div>
</template>

<script lang="ts">
import { Component, Vue } from 'nuxt-property-decorator'

@Component
export default class extends Vue {
	res = null
	async check () {
		this.res = await this.$axios.$get('auth/whoami')
	}
}
</script>
```

will fail:

```
ERROR in /Users/semenov/work/xxx/nuxt/pages/index.vue(25,26):
TS2339: Property '$axios' does not exist on type 'default'.
```

Note: due to how Nuxt.js/webpack works, you may need to explicitly import definitions in your project root `index.d.ts`:

```ts
import '@nuxtjs/axios'
```