### PR TITLE
Replace AxiosPromise to Promise

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,15 @@
-import { AxiosInstance, AxiosRequestConfig, AxiosPromise } from 'axios'
+import { AxiosInstance, AxiosRequestConfig } from 'axios'
 import Vue from 'vue'
 
 interface NuxtAxiosInstance extends AxiosInstance {
-  $request<T = any>(config: AxiosRequestConfig): AxiosPromise<T>
-  $get<T = any>(url: string, config?: AxiosRequestConfig): AxiosPromise<T>
-  $delete<T = any>(url: string, config?: AxiosRequestConfig): AxiosPromise<T>
-  $head<T = any>(url: string, config?: AxiosRequestConfig): AxiosPromise<T>
-  $options<T = any>(url: string, config?: AxiosRequestConfig): AxiosPromise<T>
-  $post<T = any>(url: string, data?: any, config?: AxiosRequestConfig): AxiosPromise<T>
-  $put<T = any>(url: string, data?: any, config?: AxiosRequestConfig): AxiosPromise<T>
-  $patch<T = any>(url: string, data?: any, config?: AxiosRequestConfig): AxiosPromise<T>
+  $request<T = any>(config: AxiosRequestConfig): Promise<T>
+  $get<T = any>(url: string, config?: AxiosRequestConfig): Promise<T>
+  $delete<T = any>(url: string, config?: AxiosRequestConfig): Promise<T>
+  $head<T = any>(url: string, config?: AxiosRequestConfig): Promise<T>
+  $options<T = any>(url: string, config?: AxiosRequestConfig): Promise<T>
+  $post<T = any>(url: string, data?: any, config?: AxiosRequestConfig): Promise<T>
+  $put<T = any>(url: string, data?: any, config?: AxiosRequestConfig): Promise<T>
+  $patch<T = any>(url: string, data?: any, config?: AxiosRequestConfig): Promise<T>
 }
 
 declare module 'vue/types/vue' {


### PR DESCRIPTION
This will fixes #161.

Before of this commit, Type Definitions define $methods (i.e: $post, $get) returns AxiosPromise<T> (which is Promise<AxiosResponse<T>>), But actually in code it returns data(T), not AxiosResponse.
So I make changes AxiosPromise to Promise, Which just resolved as data(T).