### PR TITLE
feat: add proxyHeadersIgnore in default options

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -40,7 +40,7 @@ module.exports = function nuxtAxios (_moduleOptions) {
       debug: false,
       progress: true,
       proxyHeaders: true,
-      proxyHeadersIgnore: ['accept', 'host'],
+      proxyHeadersIgnore: ['accept', 'host', 'cf-ray', 'cf-connecting-ip'],
       proxy: false,
       retry: false,
       https: false


### PR DESCRIPTION
From a suggestion from @manniL on the nuxt community discord. I added `cf-ray` and `cf-connecting-ip` to default proxy ignored header.

![](https://i.imgur.com/HXe2ozy.png)

This solution fixed my own problem with cloudflare proxy and this is also the solution for this issue (#20)