### PR TITLE
Accept-Encoding property moved to headers

### DIFF
--- a/lib/plugin.template.js
+++ b/lib/plugin.template.js
@@ -169,7 +169,7 @@ export default (ctx, inject) => {
   }
 
   if (process.server) {
-    headers.common['Accept-Encoding'] = 'gzip, deflate'
+    headers['Accept-Encoding'] = 'gzip, deflate'
   }
                              
   const axiosOptions = {


### PR DESCRIPTION
Tested it and it doesn't work on server side when it's in headers.common property.