### PR TITLE
fix(types): correct Vuex Store instance

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,6 @@
 import { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 import Vue from 'vue'
+import './vuex'
 
 interface NuxtAxiosInstance extends AxiosInstance {
   $request<T = any>(config: AxiosRequestConfig): Promise<T>

--- a/types/vuex.d.ts
+++ b/types/vuex.d.ts
@@ -1,0 +1,7 @@
+import { NuxtAxiosInstance } from '.'
+
+declare module 'vuex' {
+  interface Store<S> {
+    $axios: NuxtAxiosInstance,
+  }
+}


### PR DESCRIPTION
Hey 👋 

When [calling the inject method](https://github.com/nuxt-community/axios-module/blob/dev/lib/plugin.js#L201) we [add to the Vuex Store](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/index.js#L139) the `$axios` key.

Therefore, we need to add its typing.