### PR TITLE
fix: start $loading with request

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -111,6 +111,7 @@ const setupProgress = (axios, ctx) => {
     }
 
     currentRequests++
+    $loading().start()
   })
 
   axios.onResponse(response => {


### PR DESCRIPTION
The noop `$loading` interface accounts for `start` but it's never used. As a result, no matter the duration of the request and its progress, it'd stay invisible and only appear at the very end of the request with a 100% progress.

The behavior can be observed in this [reproduction link](https://codesandbox.io/s/2ol8m8j9mr). When you click on Request 1 the loading "blinks". When you click on Request 2, which does call start, it works.

Inside about.vue's `fetch`, progress works just fine. The reason seems to be [Nuxt calls start](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/client.js#L129) before resolving pages.

As a temporary solution you can manually call `$nuxt.$loading.start();` before a request or register a plugin that does it:
```js
export default function({ $axios }) {
  process.browser && $axios.onRequest(function() { $nuxt.$loading.start(); });
};
```
If you prefer, you can register the plugin as [client only](https://nuxtjs.org/guide/plugins#client-side-only) and remove the conditional.

Thank you both @bovas85 and @pimlie for helping me out.