### PR TITLE
feat: use `server` of nuxt.config.js to set default baseURL

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -13,6 +13,7 @@ function axiosModule(_moduleOptions) {
     moduleOptions.port ||
     process.env.PORT ||
     process.env.npm_package_config_nuxt_port ||
+    (this.options.server && this.options.server.port) ||
     3000
 
   // Default host
@@ -21,6 +22,7 @@ function axiosModule(_moduleOptions) {
     moduleOptions.host ||
     process.env.HOST ||
     process.env.npm_package_config_nuxt_host ||
+    (this.options.server && this.options.server.host) ||
     'localhost'
 
   /* istanbul ignore if */


### PR DESCRIPTION
check: https://nuxtjs.org/api/configuration-server#basic-example-code-nuxt-config-js-code-