### PR TITLE
feat: https detection

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -34,7 +34,7 @@ function axiosModule(_moduleOptions) {
   const prefix = process.env.API_PREFIX || moduleOptions.prefix || '/'
 
   // HTTPS
-  const https = !!(this.options.server && this.options.server.https)
+  const https = Boolean(this.options.server && this.options.server.https)
 
   // Apply defaults
   const options = {

--- a/lib/module.js
+++ b/lib/module.js
@@ -32,7 +32,7 @@ function axiosModule(_moduleOptions) {
 
   // Default prefix
   const prefix = process.env.API_PREFIX || moduleOptions.prefix || '/'
-  
+
   // HTTPS
   const https = this.options.server && this.options.server.https
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -34,7 +34,7 @@ function axiosModule(_moduleOptions) {
   const prefix = process.env.API_PREFIX || moduleOptions.prefix || '/'
 
   // HTTPS
-  const https = this.options.server && this.options.server.https
+  const https = !!(this.options.server && this.options.server.https)
 
   // Apply defaults
   const options = {

--- a/lib/module.js
+++ b/lib/module.js
@@ -47,7 +47,7 @@ function axiosModule(_moduleOptions) {
     proxyHeadersIgnore: ['accept', 'host', 'cf-ray', 'cf-connecting-ip', 'content-length'],
     proxy: false,
     retry: false,
-    https: https,
+    https,
     ...moduleOptions
   }
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -32,6 +32,9 @@ function axiosModule(_moduleOptions) {
 
   // Default prefix
   const prefix = process.env.API_PREFIX || moduleOptions.prefix || '/'
+  
+  // HTTPS
+  const https = this.options.server && this.options.server.https
 
   // Apply defaults
   const options = {
@@ -44,7 +47,7 @@ function axiosModule(_moduleOptions) {
     proxyHeadersIgnore: ['accept', 'host', 'cf-ray', 'cf-connecting-ip', 'content-length'],
     proxy: false,
     retry: false,
-    https: false,
+    https: https,
     ...moduleOptions
   }
 


### PR DESCRIPTION
detect if nuxt `server.https` is set, assume that https is being used, preventing CORS errors and streamlining configuration