### PR TITLE
feat(types): provide nuxt 2.9 compatible types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,10 +26,16 @@ declare module '@nuxt/vue-app' {
   interface Context {
     $axios: NuxtAxiosInstance
   }
+  interface NuxtAppOptions {
+    $axios: NuxtAxiosInstance
+  }
 }
-       
-// since nuxt 2.7.1 there is "NuxtAppOptions" for app context - see https://github.com/nuxt/nuxt.js/pull/5701
-declare module '@nuxt/vue-app' {
+
+// Nuxt 2.9+
+declare module '@nuxt/types' {
+  interface Context {
+    $axios: NuxtAxiosInstance
+  }
   interface NuxtAppOptions {
     $axios: NuxtAxiosInstance
   }


### PR DESCRIPTION
Since Nuxt 2.9, types are defined around `@nuxt/types` packages.
These changes make the module types work with Nuxt 2.9 new TypeScript specs.