### PR TITLE
feature: add an env var to disable host and port in `baseURL`

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -20,6 +20,8 @@ Environment variable `API_URL` can be used to **override** `baseURL`.
 
 **Note:** `baseURL` and `proxy` doesn't work together, you need to use `prefix` instead.
 
+**Note:** Environment variable `DISABLE_BASE_URL` can be used to disable `host` and `port` in baseURL. If this variable is set to a true value, `baseURL` will be `[PREFIX]`.
+
 ### `browserBaseURL`
 
 * Default: `baseURL` (or `prefix` when `options.proxy` is enabled)

--- a/lib/module.js
+++ b/lib/module.js
@@ -38,9 +38,9 @@ function axiosModule(_moduleOptions) {
 
   // Apply defaults
   const options = {
-    baseURL: process.env.DISABLE_BASE_URL ?
-      prefix :
-      `http://${defaultHost}:${defaultPort}${prefix}`,
+    baseURL: process.env.DISABLE_BASE_URL
+      ? prefix
+      : `http://${defaultHost}:${defaultPort}${prefix}`,
     browserBaseURL: null,
     credentials: false,
     debug: false,

--- a/lib/module.js
+++ b/lib/module.js
@@ -38,7 +38,9 @@ function axiosModule(_moduleOptions) {
 
   // Apply defaults
   const options = {
-    baseURL: `http://${defaultHost}:${defaultPort}${prefix}`,
+    baseURL: process.env.DISABLE_BASE_URL ?
+      prefix :
+      `http://${defaultHost}:${defaultPort}${prefix}`,
     browserBaseURL: null,
     credentials: false,
     debug: false,


### PR DESCRIPTION
Signed-off-by: you06 <you1474600@gmail.com>

Add an env var `DISABLE_BASE_URL`. If this var is set to a true value, axios's `baseURL` will be `prefix` only in build stage.