### PR TITLE
feat: add option to return full res on successful req

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -123,3 +123,9 @@ Also helps making consistent requests in both SSR and Client Side code.
 * Default `['host', 'accept', 'cf-ray', 'cf-connecting-ip', 'content-length']`
 
 Only efficient when `proxyHeaders` is set to true. Removes unwanted request headers to the API backend in SSR.
+
+### `fullResponse`
+
+* Default: `false`
+
+Returns the full response body when the request is successful instead of just the data.

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -36,7 +36,10 @@ const axiosExtra = {
 
 // Request helpers ($get, $post, ...)
 for (let method of ['request', 'delete', 'get', 'head', 'options', 'post', 'put', 'patch']) {
-  axiosExtra['$' + method] = function () { return this[method].apply(this, arguments).then(res => res && res.data) }
+  axiosExtra['$' + method] = function () { return this[method].apply(this, arguments).then(res => {
+    <% if (options.fullResponse) { %> return res <% } %>
+    return res && res.data
+  }) }
 }
 
 const extendAxiosInstance = axios => {


### PR DESCRIPTION
Problem:
The current default behavior of a successful request is that it only returns the data object from the response body. which prevents the developer from accessing other useful response properties like status, headers, config, request ...etc

Solution:
Added a Boolean option `fullResponse` that if set to `true` will return the full response body of a successful request.
This is not a breaking feature since this option is `false` by default which makes it completely **opt-in** and **100% backward compatible**.