### PR TITLE
feat: add `CancelToken` and `isCancel` to axios instance

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -58,10 +58,10 @@ this.$axios.$get('/user/12345', {
 })
 
 this.$axios.$post('/user/12345', {
-    name: 'new name'
-  }, {
-    cancelToken: source.token
-  })
+  name: 'new name'
+}, {
+  cancelToken: source.token
+})
 
 // cancel the request (the message parameter is optional)
 source.cancel('Operation canceled by the user.')

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -45,50 +45,43 @@ You can cancel a request using a _cancel token_.
 You can create a cancel token using the `CancelToken.source` factory as shown below:
 
 ```js
-const { CancelToken } = this.$axios;
-const source = this.$axios.CancelToken.source();
+const source = this.$axios.CancelToken.source()
 
-this.$axios
-  .$get('/user/12345', {
-    cancelToken: source.token,
+this.$axios.$get('/user/12345', {
+  cancelToken: source.token
+}).catch(error => {
+  if (this.$axios.isCancel(error)) {
+    console.log('Request canceled', error)
+  } else {
+    // handle error
+  }
+})
+
+this.$axios.$post('/user/12345', {
+    name: 'new name'
+  }, {
+    cancelToken: source.token
   })
-  .catch(error => {
-    if (this.$axios.isCancel(error)) {
-      console.log('Request canceled', error);
-    } else {
-      // handle error
-    }
-  });
-
-this.$axios.$post(
-  '/user/12345',
-  {
-    name: 'new name',
-  },
-  {
-    cancelToken: source.token,
-  },
-);
 
 // cancel the request (the message parameter is optional)
-source.cancel('Operation canceled by the user.');
+source.cancel('Operation canceled by the user.')
 ```
 
 You can also create a cancel token by passing an executor function to the `CancelToken` constructor:
 
 ```js
-const { CancelToken } = this.$axios;
-let cancel;
+const { CancelToken } = this.$axios
+let cancel
 
 this.$axios.$get('/user/12345', {
   cancelToken: new CancelToken(c => {
     // An executor function receives a cancel function as a parameter
-    cancel = c;
+    cancel = c
   }),
-});
+})
 
 // cancel the request
-cancel();
+cancel()
 ```
 
 > Note: you can cancel several requests with the same cancel token.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,31 +38,37 @@ methods: {
 
 ### Cancel token
 
-You can cancel a request using a *cancel token*.
+You can cancel a request using a _cancel token_.
 
 > The axios cancel token API is based on the withdrawn [cancelable promises proposal](https://github.com/tc39/proposal-cancelable-promises).
 
 You can create a cancel token using the `CancelToken.source` factory as shown below:
 
 ```js
-const CancelToken = this.$axios.CancelToken;
-const source = CancelToken.source();
+const { CancelToken } = this.$axios;
+const source = this.$axios.CancelToken.source();
 
-this.$axios.$get('/user/12345', {
-  cancelToken: source.token
-}).catch(function (thrown) {
-  if (this.$axios.isCancel(thrown)) {
-    console.log('Request canceled', thrown.message);
-  } else {
-    // handle error
-  }
-});
+this.$axios
+  .$get('/user/12345', {
+    cancelToken: source.token,
+  })
+  .catch(error => {
+    if (this.$axios.isCancel(error)) {
+      console.log('Request canceled', error);
+    } else {
+      // handle error
+    }
+  });
 
-this.$axios.$post('/user/12345', {
-  name: 'new name'
-}, {
-  cancelToken: source.token
-})
+this.$axios.$post(
+  '/user/12345',
+  {
+    name: 'new name',
+  },
+  {
+    cancelToken: source.token,
+  },
+);
 
 // cancel the request (the message parameter is optional)
 source.cancel('Operation canceled by the user.');
@@ -71,14 +77,14 @@ source.cancel('Operation canceled by the user.');
 You can also create a cancel token by passing an executor function to the `CancelToken` constructor:
 
 ```js
-const CancelToken = this.$axios.CancelToken;
+const { CancelToken } = this.$axios;
 let cancel;
 
 this.$axios.$get('/user/12345', {
-  cancelToken: new CancelToken(function executor(c) {
+  cancelToken: new CancelToken(c => {
     // An executor function receives a cancel function as a parameter
     cancel = c;
-  })
+  }),
 });
 
 // cancel the request

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,3 +35,54 @@ methods: {
   }
 }
 ```
+
+### Cancel token
+
+You can cancel a request using a *cancel token*.
+
+> The axios cancel token API is based on the withdrawn [cancelable promises proposal](https://github.com/tc39/proposal-cancelable-promises).
+
+You can create a cancel token using the `CancelToken.source` factory as shown below:
+
+```js
+const CancelToken = this.$axios.CancelToken;
+const source = CancelToken.source();
+
+this.$axios.$get('/user/12345', {
+  cancelToken: source.token
+}).catch(function (thrown) {
+  if (this.$axios.isCancel(thrown)) {
+    console.log('Request canceled', thrown.message);
+  } else {
+    // handle error
+  }
+});
+
+this.$axios.$post('/user/12345', {
+  name: 'new name'
+}, {
+  cancelToken: source.token
+})
+
+// cancel the request (the message parameter is optional)
+source.cancel('Operation canceled by the user.');
+```
+
+You can also create a cancel token by passing an executor function to the `CancelToken` constructor:
+
+```js
+const CancelToken = this.$axios.CancelToken;
+let cancel;
+
+this.$axios.$get('/user/12345', {
+  cancelToken: new CancelToken(function executor(c) {
+    // An executor function receives a cancel function as a parameter
+    cancel = c;
+  })
+});
+
+// cancel the request
+cancel();
+```
+
+> Note: you can cancel several requests with the same cancel token.

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -186,8 +186,8 @@ export default (ctx, inject) => {
 
   // Create new axios instance
   const axios = Axios.create(axiosOptions)
-  axios.CancelToken = Axios.CancelToken;
-  axios.isCancel = Axios.isCancel;
+  axios.CancelToken = Axios.CancelToken
+  axios.isCancel = Axios.isCancel
 
   // Extend axios proto
   extendAxiosInstance(axios)

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -186,6 +186,8 @@ export default (ctx, inject) => {
 
   // Create new axios instance
   const axios = Axios.create(axiosOptions)
+  axios.CancelToken = Axios.CancelToken;
+  axios.isCancel = Axios.isCancel;
 
   // Extend axios proto
   extendAxiosInstance(axios)


### PR DESCRIPTION
Providing a solution for https://github.com/nuxt-community/axios-module/issues/271 by adding CancelToken and isCancel to the exported axios instance.

Reference: https://github.com/axios/axios/issues/1330#issuecomment-378961682