### PR TITLE
fix(headers): don't proxy `content-md5` and `content-type`

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -58,7 +58,7 @@ function axiosModule (_moduleOptions) {
     debug: false,
     progress: true,
     proxyHeaders: true,
-    proxyHeadersIgnore: ['accept', 'host', 'cf-ray', 'cf-connecting-ip', 'content-length'],
+    proxyHeadersIgnore: ['accept', 'host', 'cf-ray', 'cf-connecting-ip', 'content-length', 'content-md5', 'content-type'],
     proxy: false,
     retry: false,
     https,


### PR DESCRIPTION
Resolve #139 