### PR TITLE
feat: allow creating new instances

### DIFF
--- a/docs/extend.md
+++ b/docs/extend.md
@@ -38,8 +38,9 @@ export default function ({ $axios, redirect }) {
 If you need to create your own axios instance which based on $axios defaults, you can use `create` method.
 
 ```js
-export default function ({ $axios, redirect }) {
-  const newInstance = $axios.create({
+export default function ({ $axios, redirect }, inject) {
+  // Create a custom axios instance
+  const api = $axios.create({
     headers: {
       common: {
         Accept: 'text/plain, */*'
@@ -47,6 +48,10 @@ export default function ({ $axios, redirect }) {
     }
   })
 
-  newInstance.setBaseURL('https://yourapi.com')
+  // Set baseURL to something different
+  api.setBaseURL('https://my_api.com')
+  
+  // Inject to context as $api
+  inject('api', api)
 }
 ```

--- a/docs/extend.md
+++ b/docs/extend.md
@@ -32,3 +32,21 @@ export default function ({ $axios, redirect }) {
   })
 }
 ```
+
+### Create new axios instance based on defaults
+
+If you need to create your own axios instance which based on $axios defaults, you can use `create` method.
+
+```js
+export default function ({ $axios, redirect }) {
+  const newInstance = $axios.create({
+    headers: {
+      common: {
+        Accept: 'text/plain, */*'
+      }
+    }
+  })
+
+  newInstance.setBaseURL('https://yourapi.com')
+}
+```

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,4 +1,5 @@
 import Axios from 'axios'
+import defu from 'defu'
 <% if (options.retry) { %>import axiosRetry from 'axios-retry'<% } %>
 
 // Axios.prototype cannot be modified
@@ -34,6 +35,13 @@ const axiosExtra = {
   onError(fn) {
     this.onRequestError(fn)
     this.onResponseError(fn)
+  },
+  create(options) {
+    const instance = Axios.create(defu(options, this.defaults))
+    extendAxiosInstance(instance)
+    instance.CancelToken = Axios.CancelToken
+    instance.isCancel = Axios.isCancel
+    return instance
   }
 }
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -37,11 +37,7 @@ const axiosExtra = {
     this.onResponseError(fn)
   },
   create(options) {
-    const instance = Axios.create(defu(options, this.defaults))
-    extendAxiosInstance(instance)
-    instance.CancelToken = Axios.CancelToken
-    instance.isCancel = Axios.isCancel
-    return instance
+    return createAxiosInstance(defu(options, this.defaults))
   }
 }
 
@@ -54,6 +50,24 @@ const extendAxiosInstance = axios => {
   for (let key in axiosExtra) {
     axios[key] = axiosExtra[key].bind(axios)
   }
+}
+
+const createAxiosInstance = axiosOptions => {
+  // Create new axios instance
+  const axios = Axios.create(axiosOptions)
+  axios.CancelToken = Axios.CancelToken
+  axios.isCancel = Axios.isCancel
+
+  // Extend axios proto
+  extendAxiosInstance(axios)
+
+  // Setup interceptors
+  <% if (options.debug) { %>setupDebugInterceptor(axios) <% } %>
+  <% if (options.credentials) { %>setupCredentialsInterceptor(axios)<% } %>
+  <% if (options.progress) { %>setupProgress(axios) <% } %>
+  <% if (options.retry) { %>axiosRetry(axios, <%= serialize(options.retry) %>)<% } %>
+
+  return axios
 }
 
 <% if (options.debug) { %>
@@ -99,7 +113,7 @@ const setupCredentialsInterceptor = axios => {
 }<% } %>
 
 <% if (options.progress) { %>
-const setupProgress = (axios, ctx) => {
+const setupProgress = (axios) => {
   if (process.server) {
     return
   }
@@ -190,19 +204,7 @@ export default (ctx, inject) => {
     axiosOptions.headers.common['accept-encoding'] = 'gzip, deflate'
   }
 
-  // Create new axios instance
-  const axios = Axios.create(axiosOptions)
-  axios.CancelToken = Axios.CancelToken
-  axios.isCancel = Axios.isCancel
-
-  // Extend axios proto
-  extendAxiosInstance(axios)
-
-  // Setup interceptors
-  <% if (options.debug) { %>setupDebugInterceptor(axios) <% } %>
-  <% if (options.credentials) { %>setupCredentialsInterceptor(axios)<% } %>
-  <% if (options.progress) { %>setupProgress(axios, ctx) <% } %>
-  <% if (options.retry) { %>axiosRetry(axios, <%= serialize(options.retry) %>)<% } %>
+  const axios = createAxiosInstance(axiosOptions)
 
   // Inject axios to the context as $axios
   ctx.$axios = axios

--- a/test/axios.test.js
+++ b/test/axios.test.js
@@ -54,6 +54,15 @@ const testSuite = () => {
     })
   })
 
+  test('createCopy', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/mounted'))
+    window.onNuxtReady(() => {
+      const $axios = window.$nuxt.$axios
+      const newInstance = $axios.create()
+      expect(newInstance.defaults.xsrfHeaderName).toBe('X-CSRF-TOKEN')
+    })
+  })
+
   test('ssr', async () => {
     const makeReq = login => axios
       .get(url('/ssr' + (login ? '?login' : '')))

--- a/test/fixture/pages/ssr.vue
+++ b/test/fixture/pages/ssr.vue
@@ -2,6 +2,8 @@
   <div>
     <div>session-{{ axiosSessionId }}</div>
     <div>encoding-${{ axiosEncoding }}$</div>
+    <div>newInstance session-{{ newInstanceSessionId }}</div>
+    <div>newInstance headers-{{ newInstanceHeaders }}</div>
   </div>
 </template>
 
@@ -14,10 +16,22 @@ export default {
     axiosSessionId () {
       return this.$axios.defaults.headers.common.SessionId
     },
-
     axiosEncoding () {
       return this.$axios.defaults.headers.common['accept-encoding']
+    },
+    newInstanceSessionId () {
+      return this.newInstance.defaults.headers.common.SessionId
+    },
+    newInstanceHeaders () {
+      return this.newInstance.defaults.headers
     }
+  },
+  created () {
+    this.newInstance = this.$axios.create({
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest'
+      }
+    })
   },
   fetch ({ app, route }) {
     const doLogin = route.query.login !== undefined


### PR DESCRIPTION
**This PR resolves #286.** 

I added new method for create copy of $axios instance based on default settings.
After that the copy is independent and may get new options so we can extend it. 
Right now we can't use nuxt/axios in our module, because we won't override axios instance created by user. 

**How it works ?**
$axios.create method returns new Axios instance, you can pass additional options to merge.

```js
const newInstance = this.$axios.create({
  headers: {
    common: {
      Accept: 'text/plain, */*'
    }
  }
})
```

After that you can use methods from this module, without override base $axios instance. 

```js
newInstance.setBaseURL('https://yourapi.com')
```

I also extended `test/fixture/pages/ssr.vue` to present how the new instance behaves. 

@pi0 Have a look at it please. 