### PR TITLE
docs: explain need to transpile defu for ie11 support

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -47,3 +47,13 @@ Add the types to your "types" array in tsconfig.json after the `@nuxt/vue-app` e
 > **Why?**
 >
 > Because of the way nuxt works the `$axios` property on the context has to be merged into the nuxt `Context` interface via [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html). Adding `@nuxtjs/axios` to your types will import the types from the package and make typescript aware of the additions to the `Context` interface.
+
+### IE11 support
+
+If you need IE11 support, you will need to transpile `defu`, a dependency of `@nuxtjs/axios`. Add the following to your `nuxt.config.js`:
+
+```js
+  build: {
+    transpile: [/^defu/]
+  },
+```


### PR DESCRIPTION
The current version of defu uses an arrow function which is not supported by IE11. This documentation change explains the need to transpile defu for projects that need to support IE11.