### PR TITLE
fix(types): extend from `AxiosStatic`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import { AxiosError, AxiosStatic, AxiosRequestConfig, AxiosResponse } from 'axios'
+import { AxiosError, AxiosRequestConfig, AxiosResponse, AxiosStatic } from 'axios'
 import Vue from 'vue'
 import './vuex'
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
+import { AxiosError, AxiosStatic, AxiosRequestConfig, AxiosResponse } from 'axios'
 import Vue from 'vue'
 import './vuex'
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@ import { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'ax
 import Vue from 'vue'
 import './vuex'
 
-interface NuxtAxiosInstance extends AxiosInstance {
+interface NuxtAxiosInstance extends AxiosStatic {
   $request<T = any>(config: AxiosRequestConfig): Promise<T>
   $get<T = any>(url: string, config?: AxiosRequestConfig): Promise<T>
   $delete<T = any>(url: string, config?: AxiosRequestConfig): Promise<T>


### PR DESCRIPTION
The error is: TS2339: Property 'CancelToken' does not exist on type 'NuxtAxiosInstance'.

https://axios.nuxtjs.org/usage#cancel-token

`const { CancelToken } = this.$axios`