### PR TITLE
fix(module): always set protocol to `https` when `https: true` is set

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -89,7 +89,7 @@ function axiosModule (_moduleOptions) {
 
   // Convert http:// to https:// if https option is on
   if (options.https === true) {
-    const https = s => s.includes('//localhost:') ? s : s.replace('http://', 'https://')
+    const https = s => s.replace('http://', 'https://')
     options.baseURL = https(options.baseURL)
     options.browserBaseURL = https(options.browserBaseURL)
   }

--- a/test/axios.test.js
+++ b/test/axios.test.js
@@ -29,7 +29,8 @@ const testSuite = () => {
     expect(addTemplate).toBeDefined()
     const call = addTemplate.mock.calls.find(args => args[0].src.includes('plugin.js'))
     const options = call[0].options
-    expect(options.baseURL.toString()).toBe('http://localhost:3000/test_api')
+    const proto = options.https ? 'https' : 'http'
+    expect(options.baseURL.toString()).toBe(`${proto}://localhost:3000/test_api`)
     expect(options.browserBaseURL.toString()).toBe('/test_api')
   })
 


### PR DESCRIPTION
HTTPS on localhost is not possible because of this change.
https://github.com/nuxt-community/axios-module/pull/93

There is no justification as to why this change has been made.

To me it feels like a developer issue and what should have been done is something along the lines of this in the config.

```https: process.env.NODE_ENV === 'development',```

As it stands at the moments the https setting is redundant in localhost and the limitation is not well documented

https://cmty.app/nuxt/axios-module/issues/c346