### PR TITLE
fix(plugin): don't convert falsy urls to string

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -180,8 +180,8 @@ const setupProgress = (axios) => {
 export default (ctx, inject) => {
   // baseURL
   const baseURL = process.browser
-      ? '<%= options.browserBaseURL %>'
-      : (process.env._AXIOS_BASE_URL_ || '<%= options.baseURL %>')
+      ? '<%= options.browserBaseURL || '' %>'
+      : (process.env._AXIOS_BASE_URL_ || '<%= options.baseURL || '' %>')
 
   // Create fresh objects for all default header scopes
   // Axios creates only one which is shared across SSR requests!


### PR DESCRIPTION
This fixes the issue that
```js
const o = {
        a: undefined
}

console.log(`${o.a}`)
```
will log `'undefined'`