### PR TITLE
docs: add algolia search

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -3,6 +3,10 @@ module.exports = {
   description: 'Axios Module for Nuxt',
   head: [['link', { rel: 'stylesheet', href: '/styles.css' }]],
   themeConfig: {
+    algolia: {
+      apiKey: 'b41badfa89f1ce270dfeaf0fdfbfbaea',
+      indexName: 'nuxtjs_axios'
+    },
     repo: 'nuxt-community/axios-module',
     docsDir: 'docs',
     editLinks: true,


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Vuepress](https://vuepress.vuejs.org/theme/default-theme-config.html#algolia-search). We thought it is a shame you can not also used this search that you can [find on vuejs for example](https://vuejs.org/).

This PR will add DocSearch to the documentation website. It will allow a user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.