### PR TITLE
fix(plugin): add missing $ prefix to globalName

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,7 +2,7 @@ import Axios from 'axios'
 import defu from 'defu'
 <% if (options.retry) { %>import axiosRetry from 'axios-retry'<% } %>
 
-const globalName = '<%= globalName %>'
+const globalName = '$<%= globalName %>'
 
 // Axios.prototype cannot be modified
 const axiosExtra = {


### PR DESCRIPTION
**Problem:**

The `globalName` equals `nuxt` if we didn't set it in `nuxt.config.js`, when you use `window[globalName]` which means `window['nuxt']` to get global `$nuxt`, will return `undefined`, you need use `window['$nuxt']` to get it.

**Solution:**

To get global `$nuxt`, you need use

```javascript
window[`$${globalName}`]
```

So we can define the variable `globalName` with a `$` prefix to make it right.

See source code below to get more info:

https://github.com/nuxt/nuxt.js/blob/85383688371f5ba7b079e1d829a1ada91bc11eaf/packages/config/src/config/_common.js#L16-L23