### PR TITLE
feat(types): add typings to axios config in `nuxt.config`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,6 +23,28 @@ interface NuxtAxiosInstance extends AxiosStatic {
   onResponseError(callback: (error: AxiosError) => void): void
 }
 
+interface AxiosOptions {
+  baseURL?: string,
+  browserBaseURL?: string,
+  credentials?: boolean,
+  debug?: boolean,
+  progress?: boolean,
+  proxyHeaders?: boolean,
+  proxyHeadersIgnore?: string[],
+  proxy?: boolean,
+  retry?: boolean,
+  https?: boolean,
+  headers?: {
+    common?: Record<string, string>,
+    delete?: Record<string, string>,
+    get?: Record<string, string>,
+    head?: Record<string, string>,
+    post?: Record<string, string>,
+    put?: Record<string, string>,
+    patch?: Record<string, string>,
+  },
+}
+
 declare module '@nuxt/vue-app' {
   interface Context {
     $axios: NuxtAxiosInstance
@@ -37,8 +59,13 @@ declare module '@nuxt/types' {
   interface Context {
     $axios: NuxtAxiosInstance
   }
+
   interface NuxtAppOptions {
     $axios: NuxtAxiosInstance
+  }
+
+  interface Configuration {
+    axios?: AxiosOptions
   }
 }
 


### PR DESCRIPTION
Hi, 
With this PR, the axios configuration will be autocompleted in nuxt.config.js for those who use typescript-runtime.

Thanks for your work,
Mathieu.