### PR TITLE
fix(plugin): hide progress bar on cancelled requests

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -161,6 +161,10 @@ const setupProgress = (axios) => {
     currentRequests--
 
     if (Axios.isCancel(error)) {
+      if (currentRequests <= 0) {
+        currentRequests = 0
+        $loading().finish()
+      }
       return
     }
 

--- a/test/fixture/api.js
+++ b/test/fixture/api.js
@@ -7,7 +7,7 @@ function sleep (ms) {
 module.exports = {
   path: '/test_api',
   async handler (req, res) {
-    const query = new URL(req.url, "http://localhost:3000").query
+    const query = new URL(req.url, 'http://localhost:3000').query
     if (query && query.delay) {
       await sleep(query.delay)
     }

--- a/test/fixture/api.js
+++ b/test/fixture/api.js
@@ -1,6 +1,19 @@
+const url = require('url')
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}   
+
 module.exports = {
   path: '/test_api',
-  handler (req, res) {
+  async handler (req, res) {
+    const query = url.parse(req.url,true).query;
+    if(query && query.delay){
+      await sleep(query.delay)
+    }
+    
     res.end(JSON.stringify({
       url: req.url,
       method: req.method

--- a/test/fixture/api.js
+++ b/test/fixture/api.js
@@ -1,5 +1,3 @@
-const url = require('url')
-
 function sleep (ms) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms)
@@ -9,7 +7,7 @@ function sleep (ms) {
 module.exports = {
   path: '/test_api',
   async handler (req, res) {
-    const query = url.URL(req.url, true).query
+    const query = new URL(req.url, "http://localhost:3000").query
     if (query && query.delay) {
       await sleep(query.delay)
     }

--- a/test/fixture/api.js
+++ b/test/fixture/api.js
@@ -1,19 +1,19 @@
 const url = require('url')
 
-function sleep(ms) {
+function sleep (ms) {
   return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}   
+    setTimeout(resolve, ms)
+  })
+}
 
 module.exports = {
   path: '/test_api',
   async handler (req, res) {
-    const query = url.parse(req.url,true).query;
-    if(query && query.delay){
+    const query = url.URL(req.url, true).query
+    if (query && query.delay) {
       await sleep(query.delay)
     }
-    
+
     res.end(JSON.stringify({
       url: req.url,
       method: req.method

--- a/test/fixture/pages/cancelToken.vue
+++ b/test/fixture/pages/cancelToken.vue
@@ -1,0 +1,33 @@
+<template>
+  <div>
+    there should be no loading bar left over:
+    <button @click="test">Fake Request</button>
+  </div>
+</template>
+
+<script>
+export default {
+  methods: {
+    test() {
+      const source = this.$axios.CancelToken.source();
+      this.$axios
+        .$post(
+          "http://localhost:3000/test_api/foo/bar?delay=1000",
+          { data: "test" },
+          {
+            cancelToken: source.token,
+          }
+        )
+        .catch((err) => {
+          if (this.$axios.isCancel(err)) {
+            console.log("request canceled");
+          }
+        });
+
+      setTimeout(function () {
+        source.cancel();
+      }, 500);
+    },
+  },
+};
+</script>


### PR DESCRIPTION
At the moment if there is a long running request that should be cancelled (like a video upload or something) the loading bar stays. 

This pr is for decrementing the request cound and hiding the progress bar if last request.