### PR TITLE
fix $loading().set(Infinity) issue

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -173,7 +173,7 @@ const setupProgress = (axios) => {
   })
 
   const onProgress = e => {
-    if (!currentRequests) {
+    if (!currentRequests || !e.total) {
       return
     }
     const progress = ((e.loaded * 100) / (e.total * currentRequests))


### PR DESCRIPTION
if Content-Length field is missing in response header, the value of e.total is 0, which will cause $loading().set(Infinity)