### PR TITLE
feat: create axios instance on req.$axios for server-middleware use

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,5 +6,8 @@ module.exports = {
   },
   extends: [
     '@nuxtjs'
-  ]
+  ],
+  rules: {
+    'no-console': 'off'
+  }
 }

--- a/docs/content/en/usage.md
+++ b/docs/content/en/usage.md
@@ -44,7 +44,7 @@ methods: {
 
 ## Server Middleware
 
-Server middleware does not have access to `Context` and thus to the axios instance that is attached to it. To help with that, an extra instance is created by this module and exposed as `process.axios`. That instance is extended in a similar way as the axios instance in `Context` with the exception that the `proxyHeaders` option is ignored.
+Server middleware does not have access to `Context` and thus to the axios instance that is attached to it. To help with that, an extra instance is created by this module and accessible from server middleware through `req.$axios`. That instance is extended in a similar way as the axios instance in `Context` with the exception that the `proxyHeaders` option is ignored.
 
 ## `$` Shortcuts
 

--- a/docs/content/en/usage.md
+++ b/docs/content/en/usage.md
@@ -42,6 +42,10 @@ methods: {
 }
 ```
 
+## Server Middleware
+
+Server middleware does not have access to `Context` and thus to the axios instance that is attached to it. To help with that, an extra instance is created by this module and exposed as `process.axios`. That instance is extended in a similar way as the axios instance in `Context` with the exception that the `proxyHeaders` option is ignored.
+
 ## `$` Shortcuts
 
 Axios plugin also supports shortcuts with `$` prefixed methods to directly get data:

--- a/lib/axios-extend.js
+++ b/lib/axios-extend.js
@@ -1,0 +1,189 @@
+const Axios = require('axios')
+const defu = require('defu')
+
+const createAxiosInstance = (axiosOptions, moduleOptions, isServer) => {
+  // Create new axios instance
+  const axios = Axios.create(axiosOptions)
+
+  // Extend axios proto
+  extendAxiosInstance(axios, moduleOptions, isServer)
+
+  return axios
+}
+
+const extendAxiosInstance = (axios, moduleOptions, isServer) => {
+  axios.CancelToken = Axios.CancelToken
+  axios.isCancel = Axios.isCancel
+
+  // Axios.prototype cannot be modified
+  const axiosExtra = {
+    setBaseURL (baseURL) {
+      this.defaults.baseURL = baseURL
+    },
+    setHeader (name, value, scopes = 'common') {
+      for (const scope of Array.isArray(scopes) ? scopes : [scopes]) {
+        if (!value) {
+          delete this.defaults.headers[scope][name]
+          return
+        }
+        this.defaults.headers[scope][name] = value
+      }
+    },
+    setToken (token, type, scopes = 'common') {
+      const value = !token ? null : (type ? type + ' ' : '') + token
+      this.setHeader('Authorization', value, scopes)
+    },
+    onRequest (fn) {
+      this.interceptors.request.use(config => fn(config) || config)
+    },
+    onResponse (fn) {
+      this.interceptors.response.use(response => fn(response) || response)
+    },
+    onRequestError (fn) {
+      this.interceptors.request.use(undefined, error => fn(error) || Promise.reject(error))
+    },
+    onResponseError (fn) {
+      this.interceptors.response.use(undefined, error => fn(error) || Promise.reject(error))
+    },
+    onError (fn) {
+      this.onRequestError(fn)
+      this.onResponseError(fn)
+    },
+    create (options) {
+      return createAxiosInstance(defu(options, this.defaults), moduleOptions, isServer)
+    }
+  }
+
+  // Request helpers ($get, $post, ...)
+  for (const method of ['request', 'delete', 'get', 'head', 'options', 'post', 'put', 'patch']) {
+    axiosExtra['$' + method] = function () { return this[method].apply(this, arguments).then(res => res && res.data) }
+  }
+
+  for (const key in axiosExtra) {
+    axios[key] = axiosExtra[key].bind(axios)
+  }
+
+  // Setup interceptors
+  if (moduleOptions.debug) {
+    setupDebugInterceptor(axios, isServer)
+  }
+  if (moduleOptions.credentials) {
+    setupCredentialsInterceptor(axios)
+  }
+  if (moduleOptions.progress && !isServer) {
+    setupProgress(axios)
+  }
+  if (moduleOptions.retry) {
+    const axiosRetry = require('axios-retry')
+    axiosRetry(axios, moduleOptions.retry)
+  }
+}
+
+const log = (level, ...messages) => console[level]('[Axios]', ...messages)
+
+const setupDebugInterceptor = (axios, isServer) => {
+  // request
+  axios.onRequestError((error) => {
+    log('error', 'Request error:', error)
+  })
+
+  // response
+  axios.onResponseError((error) => {
+    log('error', 'Response error:', error)
+  })
+  axios.onResponse((res) => {
+    log(
+      'info',
+      '[' + (res.status + ' ' + res.statusText) + ']',
+      '[' + res.config.method.toUpperCase() + ']',
+      res.config.url)
+
+    if (!isServer) {
+      console.log(res)
+    } else {
+      console.log(JSON.stringify(res.data, undefined, 2))
+    }
+
+    return res
+  })
+}
+
+const setupCredentialsInterceptor = (axios) => {
+  // Send credentials only to relative and API Backend requests
+  axios.onRequest((config) => {
+    if (config.withCredentials === undefined) {
+      if (!/^https?:\/\//i.test(config.url) || config.url.indexOf(config.baseURL) === 0) {
+        config.withCredentials = true
+      }
+    }
+  })
+}
+
+const setupProgress = (axios) => {
+  // A noop loading inteterface for when $nuxt is not yet ready
+  const noopLoading = {
+    finish: () => { },
+    start: () => { },
+    fail: () => { },
+    set: () => { }
+  }
+
+  const $loading = () => {
+    const $nuxt = typeof window !== 'undefined' && window['$<%= options.globalName %>']
+    return ($nuxt && $nuxt.$loading && $nuxt.$loading.set) ? $nuxt.$loading : noopLoading
+  }
+
+  let currentRequests = 0
+
+  axios.onRequest((config) => {
+    if (config && config.progress === false) {
+      return
+    }
+
+    currentRequests++
+  })
+
+  axios.onResponse((response) => {
+    if (response && response.config && response.config.progress === false) {
+      return
+    }
+
+    currentRequests--
+    if (currentRequests <= 0) {
+      currentRequests = 0
+      $loading().finish()
+    }
+  })
+
+  axios.onError((error) => {
+    if (error && error.config && error.config.progress === false) {
+      return
+    }
+
+    currentRequests--
+
+    if (Axios.isCancel(error)) {
+      if (currentRequests <= 0) {
+        currentRequests = 0
+        $loading().finish()
+      }
+      return
+    }
+
+    $loading().fail()
+    $loading().finish()
+  })
+
+  const onProgress = (e) => {
+    if (!currentRequests) {
+      return
+    }
+    const progress = ((e.loaded * 100) / (e.total * currentRequests))
+    $loading().set(Math.min(100, progress))
+  }
+
+  axios.defaults.onUploadProgress = onProgress
+  axios.defaults.onDownloadProgress = onProgress
+}
+
+module.exports.createAxiosInstance = createAxiosInstance

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,7 +1,7 @@
 const path = require('path')
-const Axios = require('axios')
 const consola = require('consola')
 const defu = require('defu')
+const { createAxiosInstance } = require('./axios-extend')
 
 const logger = consola.withScope('nuxt:axios')
 
@@ -111,6 +111,12 @@ function axiosModule (_moduleOptions) {
     options
   })
 
+  // Helper functions for extending axios used by the plugin and the module.
+  this.addTemplate({
+    src: path.resolve(__dirname, 'axios-extend.js'),
+    fileName: 'axios-extend.js'
+  })
+
   // Proxy integration
   if (options.proxy) {
     this.requireModule([
@@ -122,12 +128,29 @@ function axiosModule (_moduleOptions) {
   // Set _AXIOS_BASE_URL_ for dynamic SSR baseURL
   process.env._AXIOS_BASE_URL_ = options.baseURL
 
-  // Create a separate instance for server middlewares.
-  // Extended from a server-side plugin.
-  process.axios = Axios.create({ baseURL: options.baseURL })
-
   logger.debug(`baseURL: ${options.baseURL}`)
   logger.debug(`browserBaseURL: ${options.browserBaseURL}`)
+
+  // Create a separate axios instance on req.$axios for server middleware usage.
+  this.nuxt.hook('render:setupMiddleware', (app) => {
+    app.use((req, res, next) => {
+      const runtimeConfig = {
+        ...this.options.publicPrivateConfig,
+        ...this.options.privateRuntimeConfig
+      }
+      const axiosRuntimeConfig = (runtimeConfig && runtimeConfig.axios) || {}
+      const baseURL = axiosRuntimeConfig.baseURL || process.env._AXIOS_BASE_URL_ || options.baseURL || ''
+      const axiosOptions = {
+        baseURL,
+        // Create fresh objects for all default header scopes
+        // Axios creates only one which is shared across SSR requests!
+        // https://github.com/mzabriskie/axios/blob/master/lib/defaults.js
+        headers: JSON.parse(JSON.stringify(options.headers))
+      }
+      req.$axios = createAxiosInstance(axiosOptions, options, /* isServer= */true)
+      next()
+    })
+  })
 }
 
 module.exports = axiosModule

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const Axios = require('axios')
 const consola = require('consola')
 const defu = require('defu')
 
@@ -120,6 +121,10 @@ function axiosModule (_moduleOptions) {
 
   // Set _AXIOS_BASE_URL_ for dynamic SSR baseURL
   process.env._AXIOS_BASE_URL_ = options.baseURL
+
+  // Create a separate instance for server middlewares.
+  // Extended from a server-side plugin.
+  process.axios = Axios.create({ baseURL: options.baseURL })
 
   logger.debug(`baseURL: ${options.baseURL}`)
   logger.debug(`browserBaseURL: ${options.browserBaseURL}`)

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -47,25 +47,26 @@ for (const method of ['request', 'delete', 'get', 'head', 'options', 'post', 'pu
 }
 
 const extendAxiosInstance = axios => {
-  for (const key in axiosExtra) {
-    axios[key] = axiosExtra[key].bind(axios)
-  }
-}
-
-const createAxiosInstance = axiosOptions => {
-  // Create new axios instance
-  const axios = Axios.create(axiosOptions)
   axios.CancelToken = Axios.CancelToken
   axios.isCancel = Axios.isCancel
 
-  // Extend axios proto
-  extendAxiosInstance(axios)
+  for (const key in axiosExtra) {
+    axios[key] = axiosExtra[key].bind(axios)
+  }
 
   // Setup interceptors
   <% if (options.debug) { %>setupDebugInterceptor(axios) <% } %>
   <% if (options.credentials) { %>setupCredentialsInterceptor(axios)<% } %>
   <% if (options.progress) { %>setupProgress(axios) <% } %>
   <% if (options.retry) { %>axiosRetry(axios, <%= serialize(options.retry) %>)<% } %>
+}
+
+const createAxiosInstance = axiosOptions => {
+  // Create new axios instance
+  const axios = Axios.create(axiosOptions)
+
+  // Extend axios proto
+  extendAxiosInstance(axios)
 
   return axios
 }
@@ -184,6 +185,14 @@ const setupProgress = (axios) => {
   axios.defaults.onDownloadProgress = onProgress
 }<% } %>
 
+if (process.server) {
+  // Not available during testing.
+  if (process.axios && !process.axios.__extended) {
+    extendAxiosInstance(process.axios)
+    process.axios.__extended = true
+  }
+}
+
 export default (ctx, inject) => {
   // runtimeConfig
   const runtimeConfig = ctx.$config && ctx.$config.axios || {}
@@ -221,6 +230,5 @@ export default (ctx, inject) => {
   const axios = createAxiosInstance(axiosOptions)
 
   // Inject axios to the context as $axios
-  ctx.$axios = axios
   inject('axios', axios)
 }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,205 +1,14 @@
-import Axios from 'axios'
-import defu from 'defu'
-<% if (options.retry) { %>import axiosRetry from 'axios-retry'<% } %>
+import { createAxiosInstance } from './axios-extend.js'
 
-// Axios.prototype cannot be modified
-const axiosExtra = {
-  setBaseURL (baseURL) {
-    this.defaults.baseURL = baseURL
-  },
-  setHeader (name, value, scopes = 'common') {
-    for (const scope of Array.isArray(scopes) ? scopes : [ scopes ]) {
-      if (!value) {
-        delete this.defaults.headers[scope][name];
-        return
-      }
-      this.defaults.headers[scope][name] = value
-    }
-  },
-  setToken (token, type, scopes = 'common') {
-    const value = !token ? null : (type ? type + ' ' : '') + token
-    this.setHeader('Authorization', value, scopes)
-  },
-  onRequest(fn) {
-    this.interceptors.request.use(config => fn(config) || config)
-  },
-  onResponse(fn) {
-    this.interceptors.response.use(response => fn(response) || response)
-  },
-  onRequestError(fn) {
-    this.interceptors.request.use(undefined, error => fn(error) || Promise.reject(error))
-  },
-  onResponseError(fn) {
-    this.interceptors.response.use(undefined, error => fn(error) || Promise.reject(error))
-  },
-  onError(fn) {
-    this.onRequestError(fn)
-    this.onResponseError(fn)
-  },
-  create(options) {
-    return createAxiosInstance(defu(options, this.defaults))
-  }
-}
-
-// Request helpers ($get, $post, ...)
-for (const method of ['request', 'delete', 'get', 'head', 'options', 'post', 'put', 'patch']) {
-  axiosExtra['$' + method] = function () { return this[method].apply(this, arguments).then(res => res && res.data) }
-}
-
-const extendAxiosInstance = axios => {
-  axios.CancelToken = Axios.CancelToken
-  axios.isCancel = Axios.isCancel
-
-  for (const key in axiosExtra) {
-    axios[key] = axiosExtra[key].bind(axios)
-  }
-
-  // Setup interceptors
-  <% if (options.debug) { %>setupDebugInterceptor(axios) <% } %>
-  <% if (options.credentials) { %>setupCredentialsInterceptor(axios)<% } %>
-  <% if (options.progress) { %>setupProgress(axios) <% } %>
-  <% if (options.retry) { %>axiosRetry(axios, <%= serialize(options.retry) %>)<% } %>
-}
-
-const createAxiosInstance = axiosOptions => {
-  // Create new axios instance
-  const axios = Axios.create(axiosOptions)
-
-  // Extend axios proto
-  extendAxiosInstance(axios)
-
-  return axios
-}
-
-<% if (options.debug) { %>
-const log = (level, ...messages) => console[level]('[Axios]', ...messages)
-
-const setupDebugInterceptor = axios => {
-  // request
-  axios.onRequestError(error => {
-    log('error', 'Request error:', error)
-  })
-
-  // response
-  axios.onResponseError(error => {
-    log('error', 'Response error:', error)
-  })
-  axios.onResponse(res => {
-      log(
-        'info',
-        '[' + (res.status + ' ' + res.statusText) + ']',
-        '[' + res.config.method.toUpperCase() + ']',
-        res.config.url)
-
-      if (process.browser) {
-        console.log(res)
-      } else {
-        console.log(JSON.stringify(res.data, undefined, 2))
-      }
-
-      return res
-  })
-}<% } %>
-
-<% if (options.credentials) { %>
-const setupCredentialsInterceptor = axios => {
-  // Send credentials only to relative and API Backend requests
-  axios.onRequest(config => {
-    if (config.withCredentials === undefined) {
-      if (!/^https?:\/\//i.test(config.url) || config.url.indexOf(config.baseURL) === 0) {
-        config.withCredentials = true
-      }
-    }
-  })
-}<% } %>
-
-<% if (options.progress) { %>
-const setupProgress = (axios) => {
-  if (process.server) {
-    return
-  }
-
-  // A noop loading inteterface for when $nuxt is not yet ready
-  const noopLoading = {
-    finish: () => { },
-    start: () => { },
-    fail: () => { },
-    set: () => { }
-  }
-
-  const $loading = () => {
-    const $nuxt = typeof window !== 'undefined' && window['$<%= options.globalName %>']
-    return ($nuxt && $nuxt.$loading && $nuxt.$loading.set) ? $nuxt.$loading : noopLoading
-  }
-
-  let currentRequests = 0
-
-  axios.onRequest(config => {
-    if (config && config.progress === false) {
-      return
-    }
-
-    currentRequests++
-  })
-
-  axios.onResponse(response => {
-    if (response && response.config && response.config.progress === false) {
-      return
-    }
-
-    currentRequests--
-    if (currentRequests <= 0) {
-      currentRequests = 0
-      $loading().finish()
-    }
-  })
-
-  axios.onError(error => {
-    if (error && error.config && error.config.progress === false) {
-      return
-    }
-
-    currentRequests--
-
-    if (Axios.isCancel(error)) {
-      if (currentRequests <= 0) {
-        currentRequests = 0
-        $loading().finish()
-      }
-      return
-    }
-
-    $loading().fail()
-    $loading().finish()
-  })
-
-  const onProgress = e => {
-    if (!currentRequests) {
-      return
-    }
-    const progress = ((e.loaded * 100) / (e.total * currentRequests))
-    $loading().set(Math.min(100, progress))
-  }
-
-  axios.defaults.onUploadProgress = onProgress
-  axios.defaults.onDownloadProgress = onProgress
-}<% } %>
-
-if (process.server) {
-  // Not available during testing.
-  if (process.axios && !process.axios.__extended) {
-    extendAxiosInstance(process.axios)
-    process.axios.__extended = true
-  }
-}
+const options = <%= serialize(options) %>
 
 export default (ctx, inject) => {
   // runtimeConfig
   const runtimeConfig = ctx.$config && ctx.$config.axios || {}
   // baseURL
   const baseURL = process.browser
-    ? (runtimeConfig.browserBaseURL || runtimeConfig.baseURL || '<%= options.browserBaseURL || '' %>')
-      : (runtimeConfig.baseURL || process.env._AXIOS_BASE_URL_ || '<%= options.baseURL || '' %>')
+    ? (runtimeConfig.browserBaseURL || runtimeConfig.baseURL || options.browserBaseURL || '')
+      : (runtimeConfig.baseURL || process.env._AXIOS_BASE_URL_ || options.baseURL || '')
 
   // Create fresh objects for all default header scopes
   // Axios creates only one which is shared across SSR requests!
@@ -211,23 +20,23 @@ export default (ctx, inject) => {
     headers
   }
 
-  <% if (options.proxyHeaders) { %>
-  // Proxy SSR request headers headers
-  if (process.server && ctx.req && ctx.req.headers) {
-    const reqHeaders = { ...ctx.req.headers }
-    for (const h of <%= serialize(options.proxyHeadersIgnore) %>) {
-      delete reqHeaders[h]
+  if (options.proxyHeaders) {
+    // Proxy SSR request headers headers
+    if (process.server && ctx.req && ctx.req.headers) {
+      const reqHeaders = { ...ctx.req.headers }
+      for (const h of options.proxyHeadersIgnore) {
+        delete reqHeaders[h]
+      }
+      axiosOptions.headers.common = { ...reqHeaders, ...axiosOptions.headers.common }
     }
-    axiosOptions.headers.common = { ...reqHeaders, ...axiosOptions.headers.common }
   }
-  <% } %>
 
   if (process.server) {
     // Don't accept brotli encoding because Node can't parse it
     axiosOptions.headers.common['accept-encoding'] = 'gzip, deflate'
   }
 
-  const axios = createAxiosInstance(axiosOptions)
+  const axios = createAxiosInstance(axiosOptions, options, process.server)
 
   // Inject axios to the context as $axios
   inject('axios', axios)

--- a/test/axios.test.js
+++ b/test/axios.test.js
@@ -96,6 +96,17 @@ const testSuite = () => {
 
     expect(result).toBe('gzip, deflate')
   })
+
+  test('server middleware', async () => {
+    const makeReq = () => axios
+      .get(url('/check_req_axios'))
+      .then(r => r.data)
+
+    const result = await makeReq()
+
+    expect(result.hasAxios).toBe(true)
+    expect(result.axiosExtended).toBe(true)
+  })
 }
 
 describe('module', () => {

--- a/test/fixture/api.js
+++ b/test/fixture/api.js
@@ -5,16 +5,27 @@ function sleep (ms) {
 }
 
 module.exports = {
-  path: '/test_api',
-  async handler (req, res) {
-    const query = new URL(req.url, 'http://localhost:3000').query
-    if (query && query.delay) {
-      await sleep(query.delay)
-    }
+  test_api: {
+    path: '/test_api',
+    async handler (req, res) {
+      const query = new URL(req.url, 'http://localhost:3000').query
+      if (query && query.delay) {
+        await sleep(query.delay)
+      }
 
-    res.end(JSON.stringify({
-      url: req.url,
-      method: req.method
-    }))
+      res.end(JSON.stringify({
+        url: req.url,
+        method: req.method
+      }))
+    }
+  },
+  check_req_axios: {
+    path: '/check_req_axios',
+    handler (req, res) {
+      res.end(JSON.stringify({
+        hasAxios: req.$axios !== undefined,
+        axiosExtended: req.$axios && req.$axios.$get !== undefined
+      }))
+    }
   }
 }

--- a/test/fixture/nuxt.config.js
+++ b/test/fixture/nuxt.config.js
@@ -10,7 +10,10 @@ module.exports = {
   modules: [
     { handler: require('../../') }
   ],
-  serverMiddleware: ['~/api.js'],
+  serverMiddleware: [
+    require(resolve(__dirname, 'api.js')).test_api,
+    require(resolve(__dirname, 'api.js')).check_req_axios
+  ],
   axios: {
     prefix: '/test_api',
     proxy: true,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -88,7 +88,7 @@ declare module 'vue/types/vue' {
 declare global {
     namespace NodeJS {
         interface Process {
-            axios: AxiosInstance;
+            axios: NuxtAxiosInstance;
         }
     }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -85,10 +85,8 @@ declare module 'vue/types/vue' {
   }
 }
 
-declare global {
-    namespace NodeJS {
-        interface Process {
-            axios: NuxtAxiosInstance;
-        }
+declare module 'http' {
+    interface IncomingMessage {
+        $axios: NuxtAxiosInstance
     }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import { AxiosError, AxiosRequestConfig, AxiosResponse, AxiosStatic } from 'axios'
+import { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosStatic } from 'axios'
 import { IAxiosRetryConfig } from 'axios-retry'
 import Vue from 'vue'
 import './vuex'
@@ -83,4 +83,12 @@ declare module 'vue/types/vue' {
   interface Vue {
     $axios: NuxtAxiosInstance
   }
+}
+
+declare global {
+    namespace NodeJS {
+        interface Process {
+            axios: AxiosInstance;
+        }
+    }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosStatic } from 'axios'
+import { AxiosError, AxiosRequestConfig, AxiosResponse, AxiosStatic } from 'axios'
 import { IAxiosRetryConfig } from 'axios-retry'
 import Vue from 'vue'
 import './vuex'


### PR DESCRIPTION
An extra instance of axios is created and attached to "req.$axios" so
that server middlewares have access to the axios instance that has
extensions provided by this module.

The "proxyHeaders" option is ignored for that instance as it would be
both awkward to implement and potentially wrong. This is because
"proxyHeaders" is proxying requests from the request that initiated the
page request while server-middleware instance is kinda independent of
individual page requests.

Resolves #427