### PR TITLE
docs: fix typo

### DIFF
--- a/docs/content/en/index.md
+++ b/docs/content/en/index.md
@@ -28,7 +28,7 @@ Secure and easy [Axios](https://github.com/axios/axios) integration for [Nuxt](h
 
 ## Logo
 
-Axios does not have an official module yet, we decided to use the actual proposal submitted here: https://github.com/axios/axios/issues/2130
+Axios does not have an official logo yet, we decided to use the actual proposal submitted here: https://github.com/axios/axios/issues/2130
 
 ## Links
 


### PR DESCRIPTION
should be logo not module