### PR TITLE
fix: add `x-forwarded-host` to `proxyHeaderIgnore` defaults

### DIFF
--- a/docs/content/en/options.md
+++ b/docs/content/en/options.md
@@ -166,13 +166,13 @@ In SSR context, this options sets client requests headers as default headers for
 This is useful for making requests which need cookie based auth on server side.
 This also helps making consistent requests in both SSR and Client Side code.
 
-> **NOTE:** If you are directing requests to an url that is protected by CloudFlare's CDN you should set this to `false` in order to prevent CloudFlare from mistakenly detecting a reverse proxy loop and returning a 403 error.
-
 ## `proxyHeadersIgnore`
 
-* Default `['host', 'accept', 'cf-ray', 'cf-connecting-ip', 'content-length']`
+* Default `['accept', 'host', 'x-forwarded-host', 'cf-ray', 'cf-connecting-ip', 'content-length', 'content-md5', 'content-type']`
 
-This is useful and efficient only when `proxyHeaders` is set to true. Removes unwanted requests headers to the API backend in SSR.
+This is useful and effective only when `proxyHeaders` is set to true. It removes unwanted requests headers to the API backend in SSR.
+
+Ignoring the headers `x-forwarded-host`, `cf-ray`, and `cf-connecting-ip` is necessary to avoid confusing reverse proxies (including CloudFlare) and avoid causing proxy loops.
 
 ## `headers`
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -64,7 +64,7 @@ function axiosModule (_moduleOptions) {
     debug: false,
     progress: true,
     proxyHeaders: true,
-    proxyHeadersIgnore: ['accept', 'host', 'cf-ray', 'cf-connecting-ip', 'content-length', 'content-md5', 'content-type'],
+    proxyHeadersIgnore: ['accept', 'host', 'x-forwarded-host', 'cf-ray', 'cf-connecting-ip', 'content-length', 'content-md5', 'content-type'],
     proxy: false,
     retry: false,
     https,


### PR DESCRIPTION
As mentioned in #456, some reverse proxies get confused when they get an `x-forwarded-host` and cause loops or incorrectly rewriting the `host` header. I assume the proxying of this header might also cause issues with CloudFlare.
After adding this header to the ignored list my problem was fixed and I have tested the new defaults with CloudFlare reverse proxy and it's working fine.

Note: I've also updated docs to reflect new defaults and explain the purpose of that new default, and removed the note about disabling header proxying altogether when using CloudFlare since this is no longer needed thanks to this commit and previous ones that added the `cf-ray` and `cf-connecting-ip` headers to that same ignore list.