### PR TITLE
fix(types): add missing type for `create()`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,7 +23,7 @@ interface NuxtAxiosInstance extends AxiosStatic {
   onRequestError(callback: (error: AxiosError) => void): void
   onResponseError(callback: (error: AxiosError) => void): void
 
-  create(options: AxiosRequestConfig): NuxtAxiosInstance
+  create(options?: AxiosRequestConfig): NuxtAxiosInstance
 }
 
 interface AxiosOptions {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,6 +22,8 @@ interface NuxtAxiosInstance extends AxiosStatic {
   onError(callback: (error: AxiosError) => void): void
   onRequestError(callback: (error: AxiosError) => void): void
   onResponseError(callback: (error: AxiosError) => void): void
+
+  create(options: AxiosRequestConfig): NuxtAxiosInstance
 }
 
 interface AxiosOptions {


### PR DESCRIPTION
Add missing type for `create()` function inside `NuxtAxiosInstance`

resolves #420


