### PR TITLE
fix(types): update interceptors type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,11 +17,11 @@ interface NuxtAxiosInstance extends AxiosStatic {
   setHeader(name: string, value?: string | false, scopes?: string | string[]): void
   setToken(token: string | false, type?: string, scopes?: string | string[]): void
 
-  onRequest(callback: (config: AxiosRequestConfig) => void): void
-  onResponse<T = any>(callback: (response: AxiosResponse<T>) => void): void
-  onError(callback: (error: AxiosError) => void): void
-  onRequestError(callback: (error: AxiosError) => void): void
-  onResponseError(callback: (error: AxiosError) => void): void
+  onRequest(callback: (config: AxiosRequestConfig) => void | AxiosRequestConfig | Promise<AxiosRequestConfig>): void
+  onResponse<T = any>(callback: (response: AxiosResponse<T>) => void | AxiosResponse<T> | Promise<AxiosResponse<T>> ): void
+  onError(callback: (error: AxiosError) => any): void
+  onRequestError(callback: (error: AxiosError) => any): void 
+  onResponseError(callback: (error: AxiosError) => any): void
 
   create(options?: AxiosRequestConfig): NuxtAxiosInstance
 }


### PR DESCRIPTION
Update return types of interceptor functions to match axios interceptor and module logic.  
The interceptor implementation provide possibility to return config.

```js
// https://github.com/nuxt-community/axios-module/blob/master/lib/plugin.js#L24
onRequest(fn) {
 this.interceptors.request.use(config => fn(config) || config)
},
```

Also Axios interceptors can support async callbacks. And reject handlers can return any type not just `AxiosError`

```ts
// https://github.com/axios/axios/blob/master/index.d.ts#L125
export interface AxiosInterceptorManager<V> {
  use(onFulfilled?: (value: V) => V | Promise<V>, onRejected?: (error: any) => any): number;
  eject(id: number): void;
}

export interface AxiosInstance {
  interceptors: {
    request: AxiosInterceptorManager<AxiosRequestConfig>;
    response: AxiosInterceptorManager<AxiosResponse>;
  };
}
```

resolves #441