### PR TITLE
fix: replace process.browser to process.client

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -95,7 +95,7 @@ const setupDebugInterceptor = axios => {
         '[' + res.config.method.toUpperCase() + ']',
         res.config.url)
 
-      if (process.browser) {
+      if (process.client) {
         console.log(res)
       } else {
         console.log(JSON.stringify(res.data, undefined, 2))
@@ -193,7 +193,7 @@ export default (ctx, inject) => {
   // runtimeConfig
   const runtimeConfig = ctx.$config && ctx.$config.axios || {}
   // baseURL
-  const baseURL = process.browser
+  const baseURL = process.client
     ? (runtimeConfig.browserBaseURL || runtimeConfig.browserBaseUrl || runtimeConfig.baseURL || runtimeConfig.baseUrl || '<%= options.browserBaseURL || '' %>')
       : (runtimeConfig.baseURL || runtimeConfig.baseUrl || process.env._AXIOS_BASE_URL_ || '<%= options.baseURL || '' %>')
 


### PR DESCRIPTION
`process.browser` is now deprecated, so I replaced `process.browser` to `process.client`

ref: https://github.com/nuxt/nuxt.js/issues/4106