### PR TITLE
chore: npm i axios@0.28.0 performed

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@nuxtjs/proxy": "^2.1.0",
-    "axios": "^0.25.0",
+    "axios": "^0.28.0",
     "axios-retry": "^3.2.4",
     "consola": "^2.15.3",
     "defu": "^5.0.1"


### PR DESCRIPTION
Bump axios dependency to v0.28.0, resolving [CVE-2023-45857](https://github.com/advisories/GHSA-wf5p-g6vw-rhxx) vulnerability